### PR TITLE
correct error handling

### DIFF
--- a/miniapp/Makefile
+++ b/miniapp/Makefile
@@ -5,6 +5,7 @@ all: weather_app
 weather_app: weather_app.cu
 	$(NVCC) $^ -o $@ -std=c++11 -gencode arch=compute_80,code=sm_80 \
                               -gencode arch=compute_90,code=sm_90 \
+                              -gencode arch=compute_75,code=sm_75 \
                               -gencode arch=compute_90,code=compute_90
 
 clean:

--- a/miniapp/weather_app.cu
+++ b/miniapp/weather_app.cu
@@ -35,10 +35,11 @@
 #include <unistd.h>
 #include <vector>
 
-#define CUDA_CHECK(err)                                                                                      \
+#define CUDA_CHECK(cmd)                                                                                      \
+  { cudaError_t err = cmd; \
   if (err != cudaSuccess) {                                                                                  \
     std::cout << "CUDA error at " << __LINE__ << " " << cudaGetErrorString(err) << std::endl;                \
-    return -1;                                                                                               \
+    return -1;}                                                                                               \
   }
 
 __constant__ size_t month_day_boundary[13] = {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366};


### PR DESCRIPTION
The macor CUDA_CHECK calls the function it should check two times, if there is an error. This leads to incorrect behavoir for cudaGetLastError(), as the first call will reveal the error, but the second call will have no error as the previous call of cudaGetLastError() had no errors.